### PR TITLE
🤡 Ensure it works on old Bash

### DIFF
--- a/lib/bazel-bep.bash
+++ b/lib/bazel-bep.bash
@@ -81,8 +81,9 @@ process_bep() {
   local skip_count=0
   local cached_count=0
 
-  # Arrays for successful targets
+  # Arrays for successul targets
   declare -a successful_targets=()
+  declare -a successful_targets_sorted=()
 
   # Arrays for test performance tracking
   declare -a slowest_tests=()
@@ -364,8 +365,9 @@ process_bep() {
 
 "
 
-    # Sort the targets for better readability
-    readarray -t successful_targets_sorted < <(printf '%s\n' "${successful_targets[@]}" | sort)
+if [ ${#successful_targets[@]} -gt 0 ]; then
+    IFS=$'\n' successful_targets_sorted=($(printf '%s\n' "${successful_targets[@]}" | sort))
+fi
 
     # Show all targets
     for target in "${successful_targets_sorted[@]}"; do


### PR DESCRIPTION
## Changes

- Bash < 4 doesn't seem to support `readarray` as an inbuilt
